### PR TITLE
Replace fileFoldeer specific name with a generic one.

### DIFF
--- a/src/app/types/fileManagerTypes.ts
+++ b/src/app/types/fileManagerTypes.ts
@@ -13,7 +13,7 @@ export type FileManagerItemNode = {
 }
 
 export type FileFolderIdentityType = {
-	type: ItemType,
+	expandable: boolean,
 	id: string
 }
 

--- a/src/features/fileFolderControls/FileFolderControls.tsx
+++ b/src/features/fileFolderControls/FileFolderControls.tsx
@@ -6,7 +6,7 @@ import { v4 as uuidv4 } from 'uuid'
 
 type FileFolderControlsPropsType = {
 	isToDisplay?: boolean
-	type: ItemType
+	expandable: boolean
 	id: string
 	isRoot: boolean
 	onDelete: (data: FileFolderIdentityType) => void
@@ -15,8 +15,8 @@ type FileFolderControlsPropsType = {
 }
 
 const FileFolderControls: FC<FileFolderControlsPropsType> = (props) => {
-  const { type, isToDisplay = true, id, isRoot, onDelete, onAdd } = props
-  const deleteItem = () => onDelete({ type, id })
+  const { expandable, isToDisplay = true, id, isRoot, onDelete, onAdd } = props
+  const deleteItem = () => onDelete({ expandable, id })
 	
   const startAddingNewItem = (option: ItemType) => {
     onAdd({ id: uuidv4(), parentId: id, type: option })
@@ -25,7 +25,7 @@ const FileFolderControls: FC<FileFolderControlsPropsType> = (props) => {
   return <>
     {isToDisplay ?
       <>
-        { type === Item.FOLDER ?
+        { expandable ?
           <ItemCreateOptionsPopover onOptionSelect={startAddingNewItem}>
             <RiAddCircleFill />
           </ItemCreateOptionsPopover> : null

--- a/src/features/fileFolderItem/FileFolderItem.tsx
+++ b/src/features/fileFolderItem/FileFolderItem.tsx
@@ -1,14 +1,14 @@
 import {
   ExpandCollapseAction,
-  ExpandCollapseType,
   FileFolderIdentityType,
   FileManagerItemNode,
-  Item, ItemsVisibility,
+  Item,
+  ItemsVisibility,
   ItemType
 } from '../../app/types/fileManagerTypes'
-import {FcFolder, FcOpenedFolder, FcImageFile} from 'react-icons/fc'
+import {FcImageFile} from 'react-icons/fc'
 
-import {createElement, FC, useState} from 'react'
+import {FC, useState} from 'react'
 import FileFolderControls from '../fileFolderControls/FileFolderControls'
 import FileFolderName from '../fileFolderName/FileFolderName'
 import {
@@ -45,7 +45,7 @@ const FileFolderItem: FC<FileFolderPresenterPropType> = ({item, visibility}) => 
   const addNewItem = (data: FileManagerItemPayload<ItemType>) => {
     dispatch(createNewItem(data))
     cancelAddingNewItem()
-    dispatch(addVisibilityForNewItem({ type: data.type, id: data.id, parentId: data.parentId }))
+    dispatch(addVisibilityForNewItem({ expandable: data.type === Item.FOLDER, id: data.id, parentId: data.parentId }))
   }
 	
   const startAddingNewItem = (data: { id: string, type: ItemType, parentId: string }) => {
@@ -73,7 +73,7 @@ const FileFolderItem: FC<FileFolderPresenterPropType> = ({item, visibility}) => 
       {item.value.type === Item.FOLDER ? <Folder isExpended={visibility.isExpanded} onClick={collapseExpand} /> : <FcImageFile size={25} />}
       <FileFolderName item={item} onFileRename={renameFile} />
       <FileFolderControls
-        type={item.value.type}
+        expandable={item.value.type === Item.FOLDER}
         id={item.value.id}
         isRoot={!item.value.parentId}
         onDelete={deleteItem}

--- a/src/features/fileManager/metaDataSlice.ts
+++ b/src/features/fileManager/metaDataSlice.ts
@@ -27,7 +27,7 @@ const reducers = {
   addVisibilityForNewItem: (state: MetaDataState, action: PayloadAction<FileFolderIdentityType & {parentId: string}>) => {
     const expanded = { isExpanded: false }
     const displayed = { isDisplayed: state[action.payload.parentId].isExpanded }
-    const result = action.payload.type === Item.FOLDER ? { ...expanded, ...displayed } : displayed
+    const result = action.payload.expandable ? { ...expanded, ...displayed } : displayed
     
     return assoc(action.payload.id, result, state) as MetaDataState
   },

--- a/src/features/statelessComponents/NewItemAdd.tsx
+++ b/src/features/statelessComponents/NewItemAdd.tsx
@@ -17,9 +17,8 @@ const NewItemAdd: FC<NewItemAddPropsType> = ({item, onCancel, onConfirm}) => {
 	
   const onEscOrEnter = (ev: React.KeyboardEvent<HTMLElement>) => {
     if (ev.code === 'Escape') onCancel()
-    if (isEnterPressed(ev.code) && item && inputRef?.current.value) {
+    if (isEnterPressed(ev.code) && item && inputRef?.current.value)
       onConfirm({...item, name: inputRef?.current.value})
-    }
   }
 	
   return <>

--- a/src/features/statelessComponents/TreeComponent.tsx
+++ b/src/features/statelessComponents/TreeComponent.tsx
@@ -1,0 +1,5 @@
+const TreeComponent = () => {
+  return <></>
+}
+
+export default TreeComponent


### PR DESCRIPTION
The main scope of this PR is to transform `FileFolder` component into a generic and reusable one that would look something like:
`<ExpandableTree 
        expandableComponents={[collapsed,expanded]} 
        nonExpandableComponent={}
        addButton={() => {}}
        deleteButton={() => {}}
        onItemExpanded={() => {}} 
        onItemCollapsed={() => {}}  
        onItemEdit={() => {}}
        onItemDelete={() => {}}
        onItemAdd={() => {}}
        items={[]} />`